### PR TITLE
Update 2020 12 27

### DIFF
--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -131,9 +131,9 @@ RUN wget --quiet "https://github.com/conda-forge/miniforge/releases/download/${m
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 RUN conda install --quiet --yes \
-    'notebook=6.1.5' \
-    'jupyterhub=1.2.2' \
-    'jupyterlab=2.2.9' && \
+    'notebook=6.1.6' \
+    'jupyterhub=1.3.0' \
+    'jupyterlab=3.0.0' && \
     conda clean --all -f -y && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \

--- a/base-notebook/Dockerfile
+++ b/base-notebook/Dockerfile
@@ -150,7 +150,7 @@ CMD ["start-notebook.sh"]
 
 # Copy local files as late as possible to avoid cache busting
 COPY start.sh start-notebook.sh start-singleuser.sh /usr/local/bin/
-COPY jupyter_notebook_config.py /etc/jupyter/
+COPY jupyter_server_config.py /etc/jupyter/
 
 # Fix permissions on /etc/jupyter as root
 USER root

--- a/base-notebook/jupyter_server_config.py
+++ b/base-notebook/jupyter_server_config.py
@@ -8,9 +8,9 @@ import errno
 import stat
 
 c = get_config()  # noqa: F821
-c.NotebookApp.ip = '0.0.0.0'
-c.NotebookApp.port = 8888
-c.NotebookApp.open_browser = False
+c.ServerApp.ip = '0.0.0.0'
+c.ServerApp.port = 8888
+c.ServerApp.open_browser = False
 
 # https://github.com/jupyter/notebook/issues/3130
 c.FileContentsManager.delete_to_trash = False

--- a/base-notebook/jupyter_server_config.py
+++ b/base-notebook/jupyter_server_config.py
@@ -47,7 +47,7 @@ distinguished_name = req_distinguished_name
                            '-out', pem_file])
     # Restrict access to the file
     os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
-    c.NotebookApp.certfile = pem_file
+    c.ServerApp.certfile = pem_file
 
 # Change default umask for all subprocesses of the notebook server if set in
 # the environment

--- a/datascience-notebook/Dockerfile
+++ b/datascience-notebook/Dockerfile
@@ -70,7 +70,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.5*' \
+    'r-rmarkdown=2.6*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \
     'r-tidyverse=1.3*' \

--- a/r-notebook/Dockerfile
+++ b/r-notebook/Dockerfile
@@ -37,7 +37,7 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.5*' \
+    'r-rmarkdown=2.6*' \
     'r-rodbc=1.3*' \
     'r-rsqlite=2.2*' \
     'r-shiny=1.5*' \

--- a/scipy-notebook/Dockerfile
+++ b/scipy-notebook/Dockerfile
@@ -22,20 +22,20 @@ RUN conda install --quiet --yes \
     'bottleneck=1.3.*' \
     'cloudpickle=1.6.*' \
     'cython=0.29.*' \
-    'dask=2.30.*' \
+    'dask=2020.12.*' \
     'dill=0.3.*' \
     'h5py=3.1.*' \
-    'ipywidgets=7.5.*' \
+    'ipywidgets=7.6.*' \
     'ipympl=0.5.*'\
     'matplotlib-base=3.3.*' \
-    'numba=0.51.*' \
+    'numba=0.52.*' \
     'numexpr=2.7.*' \
     'pandas=1.1.*' \
     'patsy=0.5.*' \
-    'protobuf=3.13.*' \
+    'protobuf=3.14.*' \
     'pytables=3.6.*' \
-    'scikit-image=0.17.*' \
-    'scikit-learn=0.23.*' \
+    'scikit-image=0.18.*' \
+    'scikit-learn=0.24.*' \
     'scipy=1.5.*' \
     'seaborn=0.11.*' \
     'sqlalchemy=1.3.*' \
@@ -50,10 +50,9 @@ RUN conda install --quiet --yes \
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     # Also activate ipywidgets extension for JupyterLab
     # Check this URL for most recent compatibilities
-    # https://github.com/jupyter-widgets/ipywidgets/tree/master/packages/jupyterlab-manager
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager@^2.0.0 --no-build && \
-    jupyter labextension install @bokeh/jupyter_bokeh@^2.0.0 --no-build && \
-    jupyter labextension install jupyter-matplotlib@^0.7.2 --no-build && \
+    # Not compliant with jupyterlab 3.0.x see https://github.com/bokeh/bokeh/issues/10569
+    #jupyter labextension install @bokeh/jupyter_bokeh@^2.0.4 --no-build && \
+    jupyter labextension install jupyter-matplotlib@^0.7.4 --no-build && \
     jupyter lab build -y && \
     jupyter lab clean -y && \
     npm cache clean --force && \

--- a/tensorflow-notebook/Dockerfile
+++ b/tensorflow-notebook/Dockerfile
@@ -7,6 +7,6 @@ LABEL maintainer="Jupyter Project <jupyter@googlegroups.com>"
 
 # Install Tensorflow
 RUN pip install --quiet --no-cache-dir \
-    'tensorflow==2.3.1' && \
+    'tensorflow==2.4.0' && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
The following changes have been made.

- `base-notebook`
  - `Changed`: Bump `notebook`
  - `Changed`: Bump `jupyterhub`
  - `Changed`: Bump `jupyterlab` -> fixes #1167
  - `Fixed`: Fix the configuration in `jupyter_server_config.py` -> fixes #1205
- `scipy-notebook`
  - `Changed`: Bump `dask`
  - `Changed`: Bump `ipywidgets`
  - `Changed`: Bump `numba`
  - `Changed`: Bump `protobuf`
  - `Changed`: Bump `scikit-image`
  - `Changed`: Bump `scikit-learn`
  - Extensions
    - `Removed`: `jupyterlab-manager` No needed anymore see [Release Note][1]
    - `Removed`: `jupyter_bokeh` not compliant with jupyterlab 3.0 see [#10569][2]
- `r-notebook`
  - `Changed`: Bump `r-rmarkdown`
- `tensorflow-notebook`
  - `Changed`: Bump `tensorflow`
- `datascience-notebook`
  - `Changed`: Bump `r-rmarkdown`

[1]: https://ipywidgets.readthedocs.io/en/stable/changelog.html
[2]: https://github.com/bokeh/bokeh/issues/10569